### PR TITLE
Remove `return` from `finally` block

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ UNRELEASED
 ++++++++++
 
 * Dropped support for EOL Python versions and added support for Python 3.13.
+* Fix `#58 <https://github.com/pytest-dev/pytest-random-order/issues/58>`_: ``return`` in a ``finally`` block swallows exceptions and raises a warning in Python 3.14.
 
 v1.1.1 (2024-01-20)
 +++++++++++++++++++

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,8 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools_scm]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-r a"

--- a/random_order/shuffler.py
+++ b/random_order/shuffler.py
@@ -93,11 +93,7 @@ def _shuffle_items(items, bucket_key=None, disable=None, seed=None, session=None
 
 
 def _get_set_of_item_ids(items):
-    s = {}
-    try:
-        s = set(item.nodeid for item in items)
-    finally:
-        return s
+    return set(item.nodeid for item in items)
 
 
 def _disable(item, session):


### PR DESCRIPTION
This `return` swallows any exceptions that might happen inside the `try/finally` block.

While this does seem intentional, there is no reason for `set(item.nodeid ...)` to not work, given `nodeid` is a string.

Fix #58