### PR TITLE
Drop py dependency from test code

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,3 +48,33 @@ def twenty_cls_tests():
     for i in range(20):
         code.append("\tdef test_b{0}(self): self.assertTrue\n".format(str(i).zfill(2)))
     return "".join(code)
+
+
+def _deindent_source(source):
+    """
+    A minimal replacement for py.code.Source to deindent inlined test code.
+    Looks for the first non-empty line to determine deindent offset, doesn't
+    attempt to understand the code, line continuations, etc.
+    """
+    lines = source.splitlines()
+    for line in lines:
+        stripped = line.lstrip()
+        if stripped:
+            offset = len(line) - len(stripped)
+            break
+    else:
+        offset = 0
+
+    output_lines = []
+    for line in lines:
+        output_lines.append(line[offset:])
+
+    return "\n".join(output_lines)
+
+
+@pytest.fixture
+def deindent_source():
+    """
+    Returns a helper function to deindent inlined source code.
+    """
+    return _deindent_source

--- a/tests/test_actual_test_runs.py
+++ b/tests/test_actual_test_runs.py
@@ -2,12 +2,11 @@
 import collections
 import re
 
-import py
 import pytest
 
 
 @pytest.fixture
-def tmp_tree_of_tests(testdir):
+def tmp_tree_of_tests(testdir, deindent_source):
     """
     Creates a directory structure:
         tmpdir/
@@ -25,7 +24,7 @@ def tmp_tree_of_tests(testdir):
     sup = testdir.mkpydir("shallow_tests")
 
     sup.join("test_a.py").write(
-        py.code.Source("""
+        deindent_source("""
         def test_a1():
             assert False
         def test_a2():
@@ -36,7 +35,7 @@ def tmp_tree_of_tests(testdir):
     )
 
     sup.join("test_ax.py").write(
-        py.code.Source("""
+        deindent_source("""
         def test_ax1():
             assert True
         def test_ax2():
@@ -49,7 +48,7 @@ def tmp_tree_of_tests(testdir):
     sub = testdir.mkpydir("shallow_tests/deep_tests")
 
     sub.join("test_b.py").write(
-        py.code.Source("""
+        deindent_source("""
         def test_b1():
             assert True
         def test_b2():
@@ -60,14 +59,14 @@ def tmp_tree_of_tests(testdir):
     )
 
     sub.join("test_c.py").write(
-        py.code.Source("""
+        deindent_source("""
         def test_c1():
             assert True
     """)
     )
 
     sub.join("test_d.py").write(
-        py.code.Source("""
+        deindent_source("""
         def test_d1():
             assert True
         def test_d2():
@@ -76,7 +75,7 @@ def tmp_tree_of_tests(testdir):
     )
 
     sub.join("test_e.py").write(
-        py.code.Source("""
+        deindent_source("""
         from unittest import TestCase
         class EeTest(TestCase):
             def test_ee1(self):

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
-import py
 import pytest
 
 
 @pytest.fixture
-def tmp_tree_of_tests(testdir):
+def tmp_tree_of_tests(testdir, deindent_source):
     """
     Creates a directory structure:
         tmpdir/
@@ -16,7 +15,7 @@ def tmp_tree_of_tests(testdir):
     utils_package.join("__init__.py").write("")
 
     utils_package.join("foo.py").write(
-        py.code.Source('''
+        deindent_source('''
         def add(a, b):
             """
             >>> add(1, 1)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist = py{39,310,311,312,313}
 
 [testenv]
 deps =
-    py
     pytest-xdist
 commands =
     pytest tests --color=yes


### PR DESCRIPTION
Issue #86 asked for a removal of the legacy `py` library dependency.  
This change implements a minimal replacement for `py.code.Source` that  
we can use to deindent the inlined Python source code embedded in the  
`pytest-random-order`'s own tests.

Thanks for maintaining the plugin that helped me debug flaky tests  
on countless occasions!

Closes #86 